### PR TITLE
Engine: Make second parameter mandatory (Fix open_basedir restriction)

### DIFF
--- a/src/Bridges/Nette/WebLoaderExtension.php
+++ b/src/Bridges/Nette/WebLoaderExtension.php
@@ -89,16 +89,18 @@ class WebLoaderExtension extends CompilerExtension
 
 	private function setupWebLoader()
 	{
+		$arguments = [$this->config['outputDir']];
+
+		if ($this->config['documentRoot']) {
+			$arguments[] = $this->config['documentRoot'];
+		}
+
 		$webLoader = $this->builder->addDefinition($this->prefix(self::ENGINE_PREFIX))
 			->setFactory(self::ENGINE_CLASSNAME)
-			->setArguments([$this->config['outputDir']]);
+			->setArguments($arguments);
 
 		if ($this->config['disableCache']) {
 			$webLoader->addSetup('disableCache');
-		}
-
-		if ($this->config['documentRoot']) {
-			$webLoader->addSetup('setDocumentRoot', [$this->config['documentRoot']]);
 		}
 
 		if ($this->config['filesCollections']) {


### PR DESCRIPTION
Hi @Machy8 
If server is using `open_basedir` restrictions it is not working.
Main problem is default value of $documentRoot in [Engine](https://github.com/Machy8/webloader/compare/master...RiKap:patch-1?expand=1#diff-c8dd6bba68a2ee60191cd7f219df22fcL40). Because it is root of server. Function `setDocumentRoot()` in Compiler will try check if given value `/` is directory, but it fails because of `open_basedir` restrictions.

After these changes it is OK. But it is BC break because $documentRoot is now mandatory.