### PR TITLE
Fix compatibility with nette/di 3.0

### DIFF
--- a/src/Bridges/Nette/WebLoaderExtension.php
+++ b/src/Bridges/Nette/WebLoaderExtension.php
@@ -15,6 +15,7 @@ namespace WebLoader\Bridges\Nette;
 
 use Nette\DI\CompilerExtension;
 use Nette\DI\ContainerBuilder;
+use Nette\DI\Helpers;
 
 
 class WebLoaderExtension extends CompilerExtension
@@ -56,8 +57,10 @@ class WebLoaderExtension extends CompilerExtension
 
 	public function loadConfiguration(): void
 	{
-		$this->config = $this->getConfig($this->defaults);
 		$this->builder = $this->getContainerBuilder();
+
+		$this->config = $this->validateConfig($this->defaults);
+		$this->config = Helpers::expand($this->config, $this->builder->parameters);
 
 		$this->setupTracyPanel();
 		$this->setupWebLoader();


### PR DESCRIPTION
- Parameter for `getConfig()` was deprecated in 2.4
- In 3.0 was removed

This fix is compatible with nette 2.4 and 3.0